### PR TITLE
Fixed module name

### DIFF
--- a/app/models/constant_property_type.rb
+++ b/app/models/constant_property_type.rb
@@ -1,4 +1,4 @@
-module Spree
+module ConstantPropertyType
   PROPERTY_SHOW_LEFT_NORMAL  = 'left_normal'
   PROPERTY_SHOW_LEFT_NAME    = 'left_name'
   PROPERTY_SHOW_LEFT_ICON    = 'left_icon'

--- a/app/views/spree/products/_enhanced_properties_in_left.html.erb
+++ b/app/views/spree/products/_enhanced_properties_in_left.html.erb
@@ -1,6 +1,6 @@
 <div data-hook="product_properties">
 
-  <% ConstantPropertyType.left_properties.each do |show_type| %>
+  <% ConstantPropertyType::PROPERTIES_LEFT.each do |show_type| %>
     <% unless @product_properties.hash_for(show_type).empty? %>
       <% for title in @product_properties.hash_for(show_type).keys %>
 

--- a/app/views/spree/products/_enhanced_properties_in_right.html.erb
+++ b/app/views/spree/products/_enhanced_properties_in_right.html.erb
@@ -1,6 +1,6 @@
 <div data-hook="product_properties_below_description">
 
-  <% ConstantPropertyType.right_properties.each do |show_type| %>
+  <% ConstantPropertyType::PROPERTIES_RIGHT.each do |show_type| %>
     <% unless @product_properties.hash_for(show_type).empty? %>
       <% for title in @product_properties.hash_for(show_type).keys %>
         <h6 class="product-section-title"><%= title %></h6>


### PR DESCRIPTION
@pecuerre the module name was set incorrectly. Here's a fix for it. :v: 

I discovered the error when I tried to create a new Property Type (admin/property_types/new).
